### PR TITLE
2 ability to delete requests from dashboard

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=http://localhost:8080

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://api.secsock.secso.cc

--- a/frontend/src/components/EULA.tsx
+++ b/frontend/src/components/EULA.tsx
@@ -7,10 +7,10 @@ const EULA = ({ onAccept }: { onAccept: () => void }) => {
         <Typography variant="h1">Welcome to SecSock</Typography>
 
         <Typography variant="h6" mb={3}>
-          DISCLAIMER: this tool is intended for educational purposes.
-          Performing hacking attempts on computers that you do not own (without
-          permission) is illegal! Do not attempt to gain access to a device or
-          service that you do not own.
+          DISCLAIMER: this tool is intended for educational purposes. Performing
+          hacking attempts on computers that you do not own (without permission)
+          is illegal! Do not attempt to gain access to a device or service that
+          you do not own.
         </Typography>
 
         <Button

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -9,7 +9,10 @@ import Navbar from './Navbar';
 import Footer from './Footer';
 import notificationSound from '../assets/request_received_notification.mp3';
 
-const backendURL = "api.secsock.secso.cc"
+const backendURL = import.meta.env.VITE_BACKEND_URL;
+const backendDomain = backendURL.split("//")[1];
+console.log(backendDomain);
+// const backendURL = "api.secsock.secso.cc"
 
 function Home() {
   const [token, setToken] = useState<string | null>(null);
@@ -28,7 +31,7 @@ function Home() {
   };
 
   const copyToClipboard = () => {
-    navigator.clipboard.writeText('https://' + backendURL + '/hook/' + token);
+    navigator.clipboard.writeText(backendURL + '/hook/' + token);
     toast('Copied to clipboard', {
       position: 'top-right',
       autoClose: 3000,
@@ -50,7 +53,7 @@ function Home() {
     }
 
     // Get new token
-    const res = await fetch(`https://${backendURL}/new`);
+    const res = await fetch(`${backendURL}/new`);
     const data = await res.json();
     setToken(data.token);
     Cookies.set('token', data.token, { expires: 7 });
@@ -60,7 +63,7 @@ function Home() {
 
   const fetchLogs = useCallback(async (token: string) => {
     try {
-      const res = await fetch(`https://${backendURL}/requests/${token}`);
+      const res = await fetch(`${backendURL}/requests/${token}`);
       const data = await res.json();
       setLogs(data.reverse());
     } catch (err) {
@@ -79,7 +82,8 @@ function Home() {
         wsRef.current.close();
       }
 
-      const ws = new WebSocket(`wss://${backendURL}/ws/${token}`);
+      // Need a way to make this wss automatically for prod, wss doesn't work in dev environment
+      const ws = new WebSocket(`ws://${backendDomain}/ws/${token}`);
       ws.onmessage = (event) => {
         toast('Received a request', {
           position: 'top-right',
@@ -159,7 +163,7 @@ function Home() {
                     variant="text"
                     sx={{ my: 1, fontSize: '1rem' }}
                   >
-                    https://{backendURL}/hook/{token}
+                    {backendURL}/hook/{token}
                   </Button>
                 </Typography>
                 <Button

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -10,9 +10,7 @@ import Footer from './Footer';
 import notificationSound from '../assets/request_received_notification.mp3';
 
 const backendURL = import.meta.env.VITE_BACKEND_URL;
-const backendDomain = backendURL.split("//")[1];
-console.log(backendDomain);
-// const backendURL = "api.secsock.secso.cc"
+const backendDomain = backendURL.split('//')[1];
 
 function Home() {
   const [token, setToken] = useState<string | null>(null);
@@ -42,6 +40,7 @@ function Home() {
       progress: undefined,
       theme: theme.palette.mode,
       transition: Bounce,
+      pauseOnFocusLoss: false,
     });
   };
 
@@ -90,6 +89,7 @@ function Home() {
           autoClose: 3000,
           theme: theme.palette.mode,
           transition: Bounce,
+          pauseOnFocusLoss: false,
         });
 
         playSound();
@@ -205,7 +205,7 @@ function Home() {
                   flexGrow: 1,
                 }}
               >
-                <RequestAccordion logs={logs} />
+                <RequestAccordion logs={logs} token={token} setLogs={setLogs} />
               </Box>
             </Box>
           </Box>

--- a/frontend/src/components/types.ts
+++ b/frontend/src/components/types.ts
@@ -1,4 +1,5 @@
 export type WebhookRequest = {
+  id: string;
   ip: string;
   method: string;
   headers: Record<string, string>;


### PR DESCRIPTION
Completed feature implementation to allow users to delete requests from the dashboard.

Minor changes:
- Readded CORS protection (oops accidentally disabled it)
- Made it so toastify notification banner countdown doesn't stop if users isn't focused on the page